### PR TITLE
Ensure the labels are the right dtype, and add test to make sure it works with torchvision models

### DIFF
--- a/smallssd/data.py
+++ b/smallssd/data.py
@@ -113,7 +113,7 @@ class LabelledData(BaseDataset):
 
         return {
             LabelKeys.BOXES: torch.tensor(boxes).float(),
-            LabelKeys.LABELS: torch.tensor(labels).int(),
+            LabelKeys.LABELS: torch.tensor(labels).to(torch.int64),
         }
 
     @staticmethod


### PR DESCRIPTION
`.int()` returns a tensor of type `int32` - we want it to be `int64`.