### PR TITLE
Exclude MacOS metadata files ('._*') from the images glob.

### DIFF
--- a/smallssd/data.py
+++ b/smallssd/data.py
@@ -42,7 +42,7 @@ class BaseDataset:
                     f"it can be downloaded by setting download=True"
                 )
 
-        self.image_paths = list((self.datafolder / IMAGES).glob("*.jpg"))
+        self.image_paths = list((self.datafolder / IMAGES).glob("[!._]*.jpg"))
         self.transforms = transforms
 
     def __len__(self) -> int:


### PR DESCRIPTION
The Zenodo dataset contains files with names like `._5f2045d1ea85566809f8164a687c05d637fa9f78.jpg` in some image directories (MacOS metadata files). Under linux these are picked up by the pathlib.Path.glob() function. This change ensures the files are excluded.